### PR TITLE
Fix version file syntax error

### DIFF
--- a/OldPartsRedux.version
+++ b/OldPartsRedux.version
@@ -1,31 +1,26 @@
 {
-    "NAME":"Old Parts Redux",
-"URL":"https://github.com/TriggeredSnake/OldPartsRedux/blob/master/OldPartsRedux.version",
-    "DOWNLOAD":"https://spacedock.info/mod/1744/Old%20Parts%20Redux/download/0.9.1",
+    "NAME": "Old Parts Redux",
+    "URL": "https://github.com/TriggeredSnake/OldPartsRedux/raw/master/OldPartsRedux.version",
+    "DOWNLOAD": "https://spacedock.info/mod/1744/Old%20Parts%20Redux/download/0.10.0",
+    "VERSION": {
+        "MAJOR": 0,
+        "MINOR": 10,
+        "PATCH": 0,
+        "BUILD": 0
     },
-    "VERSION":
-    {
-        "MAJOR":0,
-        "MINOR":9,
-        "PATCH":0,
-        "BUILD":0
+    "KSP_VERSION": {
+        "MAJOR": 1,
+        "MINOR": 8,
+        "PATCH": 0
     },
-    "KSP_VERSION":
-    {
-        "MAJOR":1,
-        "MINOR":7,
-        "PATCH":1
+    "KSP_VERSION_MIN": {
+        "MAJOR": 1,
+        "MINOR": 0,
+        "PATCH": 0
     },
-    "KSP_VERSION_MIN":
-    {
-        "MAJOR":1,
-        "MINOR":0,
-        "PATCH":0
-    },
-    "KSP_VERSION_MAX":
-    {
-        "MAJOR":1,
-        "MINOR":9,
-        "PATCH":9
+    "KSP_VERSION_MAX": {
+        "MAJOR": 1,
+        "MINOR": 9,
+        "PATCH": 9
     }
 }


### PR DESCRIPTION
Hi @TriggeredSnake,

[As originally reported by @linuxgurugamer on the forum](https://forum.kerbalspaceprogram.com/index.php?/topic/172487-1xx-old-parts-redux-for-all-your-nostalgic-needs/&do=findComment&comment=3333577), there's a syntax error in the version file. The close brace on line 5 ends the overall file contents prematurely, after which any additional data is invalid. Now this is fixed.

In addition, I've taken the liberty of copying the latest versioning data from the download on SpaceDock.

Fixing these things in the next download will allow KSP-AVC and CKAN to take advantage of the versioning data provided. You will even be able to use the copy of the file here on GitHub to update the compatibility of the latest release after the fact by editing the `KSP_VERSION_MAX` property as needed.

Cheers!